### PR TITLE
Add AsyncTransport, async iter views, and fix async cache callback

### DIFF
--- a/tiled/client/cache_control.py
+++ b/tiled/client/cache_control.py
@@ -2,6 +2,7 @@
 Adapted from https://raw.githubusercontent.com/obendidi/httpx-cache/main/httpx_cache/transport.py
 in accordance with its BSD-3 license
 """
+
 import logging
 import typing as tp
 from datetime import datetime, timedelta, timezone
@@ -92,12 +93,13 @@ class ByteStreamWrapper(httpx.ByteStream):
     async def __aiter__(self) -> tp.AsyncIterator[bytes]:
         """Iterate over the async stream object and store it's chunks in a content.
 
-        After the stream is completed call the async callback with content as argument.
+        After the stream is completed call the callback with content as argument.
+        The callback is synchronous (cache.set is backed by SQLite).
         """
         async for chunk in self.stream:
             self.content.extend(chunk)
             yield chunk
-        await self.callback(bytes(self.content))
+        self.callback(bytes(self.content))
 
 
 class CacheControl:

--- a/tiled/client/transport.py
+++ b/tiled/client/transport.py
@@ -2,6 +2,7 @@
 Adapted from https://raw.githubusercontent.com/obendidi/httpx-cache/main/httpx_cache/transport.py
 in accordance with its BSD-3 license
 """
+
 import typing as tp
 
 import httpx
@@ -12,6 +13,102 @@ from .logger import collect_request, collect_response, log_request, log_response
 from .utils import TiledResponse
 
 
+def _check_cache(request, cache, controller):
+    """Check if a cached response exists and is usable.
+
+    Returns the cached response if fresh and valid, or None.
+    As a side-effect, may set If-None-Match header for revalidation
+    or delete stale cache entries.
+    """
+    cached_response = None
+    if (cache is not None) and controller.is_request_cacheable(request):
+        if __debug__:
+            logger.debug("Checking cache for: %s", request)
+        cached_response = cache.get(request)
+        if cached_response is not None:
+            if controller.is_response_fresh(request=request, response=cached_response):
+                if not controller.needs_revalidation(
+                    request=request, response=cached_response
+                ):
+                    if __debug__:
+                        logger.debug("Using cached response for: %s", request)
+                        log_request(request)
+                        collect_request(request)
+                    return cached_response
+                if __debug__:
+                    logger.debug("Revalidating cached response for: %s", request)
+                request.headers["If-None-Match"] = cached_response.headers["ETag"]
+            else:
+                if __debug__:
+                    logger.debug("Cached response is stale, deleting: %s", request)
+                cache.delete(request)
+        else:
+            if __debug__:
+                logger.debug("No valid cached response found in cache for: %s", request)
+    return cached_response
+
+
+def _update_cache(response, cached_response, request, cache, controller):
+    """Post-process a response: set its class, log it, and update the cache.
+
+    Returns the cached response if the server returned 304 Not Modified,
+    otherwise returns None (the caller should use the original response).
+    """
+    response.__class__ = TiledResponse
+    response.request = request
+    if __debug__:
+        # Log the actual server traffic, not the cached response.
+        log_response(response)
+        # But, below _collect_ the response with the content in it.
+
+    if cache is not None:
+        if response.status_code == httpx.codes.NOT_MODIFIED:
+            if __debug__:
+                logger.debug("Server validated as fresh cached entry for: %s", request)
+                collect_response(cached_response)
+            return cached_response
+
+        if controller.is_response_cacheable(request=request, response=response):
+            if cache.readonly:
+                if __debug__:
+                    logger.debug("Cache is read-only; will not store")
+            elif not cache.write_safe():
+                if __debug__:
+                    logger.debug(
+                        "Cannot write to cache from another thread; will not store"
+                    )
+            else:
+                if hasattr(response, "_content"):
+                    is_stored = cache.set(request=request, response=response)
+                    if __debug__:
+                        if is_stored:
+                            logger.debug("Caching response for: %s", request)
+                        else:
+                            logger.debug(
+                                "Declined to store large response for: %s", request
+                            )
+                else:
+                    # Wrap the response with cache callback:
+                    def _callback(content: bytes) -> None:
+                        is_stored = cache.set(
+                            request=request, response=response, content=content
+                        )
+                        if __debug__:
+                            if is_stored:
+                                logger.debug("Caching response for: %s", request)
+                            else:
+                                logger.debug(
+                                    "Declined to store large response for: %s",
+                                    request,
+                                )
+
+                    response.stream = ByteStreamWrapper(
+                        stream=response.stream,
+                        callback=_callback,  # type: ignore
+                    )
+    return None
+
+
 class Transport(httpx.BaseTransport):
     """Custom transport, implementing caching and custom compression encodings.
 
@@ -19,7 +116,7 @@ class Transport(httpx.BaseTransport):
         transport (optional): an existing httpx transport, if no transport
             is given, defaults to an httpx.HTTPTransport with default args.
         cache (optional): cache to use with this transport, defaults to
-            httpx_cache.DictCache
+            no cache.
         cacheable_methods: methods that are allowed to be cached, defaults to ['GET']
         cacheable_status_codes: status codes that are allowed to be cached,
             defaults to: (200, 203, 300, 301, 308)
@@ -54,170 +151,86 @@ class Transport(httpx.BaseTransport):
             self.cache.close()
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
-        # check if request is cacheable
-        if (self.cache is not None) and self.controller.is_request_cacheable(request):
-            if __debug__:
-                logger.debug("Checking cache for: %s", request)
-            cached_response = self.cache.get(request)
-            if cached_response is not None:
-                if self.controller.is_response_fresh(
-                    request=request, response=cached_response
-                ):
-                    if not self.controller.needs_revalidation(
-                        request=request, response=cached_response
-                    ):
-                        if __debug__:
-                            logger.debug("Using cached response for: %s", request)
-                            log_request(request)
-                            collect_request(request)
-                        return cached_response
-                    if __debug__:
-                        logger.debug("Revalidating cached response for: %s", request)
-                    request.headers["If-None-Match"] = cached_response.headers["ETag"]
-                else:
-                    if __debug__:
-                        logger.debug("Cached response is stale, deleting: %s", request)
-                    self.cache.delete(request)
-            else:
-                if __debug__:
-                    logger.debug(
-                        "No valid cached response found in cache for: %s", request
-                    )
+        cached_response = _check_cache(request, self.cache, self.controller)
+        if cached_response is not None:
+            return cached_response
 
         # Call original transport
         if __debug__:
             log_request(request)
             collect_request(request)
         response = self.transport.handle_request(request)
-        response.__class__ = TiledResponse
-        response.request = request
-        if __debug__:
-            # Log the actual server traffic, not the cached response.
-            log_response(response)
-            # But, below _collect_ the response with the content in it.
 
-        if self.cache is not None:
-            if response.status_code == httpx.codes.NOT_MODIFIED:
-                if __debug__:
-                    logger.debug(
-                        "Server validated as fresh cached entry for: %s", request
-                    )
-                    collect_response(cached_response)
-                return cached_response
-
-            if self.controller.is_response_cacheable(
-                request=request, response=response
-            ):
-                if self.cache.readonly:
-                    if __debug__:
-                        logger.debug("Cache is read-only; will not store")
-                elif not self.cache.write_safe():
-                    if __debug__:
-                        logger.debug(
-                            "Cannot write to cache from another thread; will not store"
-                        )
-                else:
-                    if hasattr(response, "_content"):
-                        is_stored = self.cache.set(request=request, response=response)
-                        if __debug__:
-                            if is_stored:
-                                logger.debug("Caching response for: %s", request)
-                            else:
-                                logger.debug(
-                                    "Declined to store large response for: %s", request
-                                )
-                    else:
-                        # Wrap the response with cache callback:
-                        def _callback(content: bytes) -> None:
-                            is_stored = self.cache.set(
-                                request=request, response=response, content=content
-                            )
-                            if __debug__:
-                                if is_stored:
-                                    logger.debug("Caching response for: %s", request)
-                                else:
-                                    logger.debug(
-                                        "Declined to store large response for: %s",
-                                        request,
-                                    )
-
-                        response.stream = ByteStreamWrapper(
-                            stream=response.stream, callback=_callback  # type: ignore
-                        )
+        revalidated = _update_cache(
+            response, cached_response, request, self.cache, self.controller
+        )
+        if revalidated is not None:
+            return revalidated
         if __debug__:
             collect_response(response)
         return response
 
 
-# For when we implement an Async client
-#
-# class AsyncCacheControlTransport(httpx.AsyncBaseTransport):
-#     """Async CacheControl transport for httpx_cache.
-#
-#     Args:
-#         transport (optional): an existing httpx async-transport, if no transport
-#             is given, defaults to an httpx.AsyncHTTPTransport with default args.
-#         cache (optional): cache to use with this transport, defaults to
-#             httpx_cache.DictCache
-#         cacheable_methods: methods that are allowed to be cached, defaults to ['GET']
-#         cacheable_status_codes: status codes that are allowed to be cached,
-#             defaults to: (200, 203, 300, 301, 308)
-#     """
-#
-#     def __init__(
-#         self,
-#         *,
-#         transport: tp.Optional[httpx.AsyncBaseTransport] = None,
-#         cache: tp.Optional[BaseCache] = None,
-#         cacheable_methods: tp.Tuple[str, ...] = ("GET",),
-#         cacheable_status_codes: tp.Tuple[int, ...] = (200, 203, 300, 301, 308),
-#         always_cache: bool = False,
-#     ):
-#         self.controller = CacheControl(
-#             cacheable_methods=cacheable_methods,
-#             cacheable_status_codes=cacheable_status_codes,
-#             always_cache=always_cache,
-#         )
-#         self.transport = transport or httpx.AsyncHTTPTransport()
-#         self.cache = cache or DictCache()
-#
-#     async def aclose(self) -> None:
-#         await self.cache.aclose()
-#         await self.transport.aclose()
-#
-#     async def handle_async_request(self, request: httpx.Request) -> TiledResponse:
-#         # check if request is cacheable
-#         if self.controller.is_request_cacheable(request):
-#             logger.debug(f"Checking cache for: %s", request)
-#             cached_response = await self.cache.aget(request)
-#             if cached_response is not None:
-#                 logger.debug(f"Found cached response for: %s", request)
-#                 if self.controller.is_response_fresh(
-#                     request=request, response=cached_response
-#                 ):
-#                     setattr(cached_response, "from_cache", True)
-#                     return cached_response
-#                 else:
-#                     logger.debug(f"Cached response is stale, deleting: %s", request)
-#                     await self.cache.adelete(request)
-#
-#         # Request is not in cache, call original transport
-#         response = await self.transport.handle_async_request(request)
-#
-#         if self.controller.is_response_cacheable(request=request, response=response):
-#             if hasattr(response, "_content"):
-#                 logger.debug(f"Caching response for: %s", request)
-#                 await self.cache.aset(request=request, response=response)
-#             else:
-#                 # Wrap the response with cache callback:
-#                 async def _callback(content: bytes) -> None:
-#                     logger.debug(f"Caching response for: %s", request)
-#                     await self.cache.aset(
-#                         request=request, response=response, content=content
-#                     )
-#
-#                 response.stream = ByteStreamWrapper(
-#                     stream=response.stream, callback=_callback  # type: ignore
-#                 )
-#         setattr(response, "from_cache", False)
-#         return response
+class AsyncTransport(httpx.AsyncBaseTransport):
+    """Async custom transport, implementing caching and custom compression encodings.
+
+    Mirrors :class:`Transport` but for use with :class:`httpx.AsyncClient`.
+
+    Args:
+        transport (optional): an existing httpx async transport, if no transport
+            is given, defaults to an httpx.AsyncHTTPTransport with default args.
+        cache (optional): cache to use with this transport.
+        cacheable_methods: methods that are allowed to be cached, defaults to ['GET']
+        cacheable_status_codes: status codes that are allowed to be cached,
+            defaults to: (200, 203, 300, 301, 308)
+    """
+
+    def __init__(
+        self,
+        *,
+        transport: tp.Optional[httpx.AsyncBaseTransport] = None,
+        cache: tp.Optional[Cache] = None,
+        cacheable_methods: tp.Tuple[str, ...] = ("GET",),
+        cacheable_status_codes: tp.Tuple[int, ...] = (
+            httpx.codes.OK,
+            httpx.codes.NON_AUTHORITATIVE_INFORMATION,
+            httpx.codes.MULTIPLE_CHOICES,
+            httpx.codes.MOVED_PERMANENTLY,
+            httpx.codes.PERMANENT_REDIRECT,
+        ),
+        always_cache: bool = False,
+    ):
+        self.controller = CacheControl(
+            cacheable_methods=cacheable_methods,
+            cacheable_status_codes=cacheable_status_codes,
+            always_cache=always_cache,
+        )
+        self.transport = transport or httpx.AsyncHTTPTransport()
+        self.cache = cache
+
+    async def aclose(self) -> None:
+        await self.transport.aclose()
+        if self.cache is not None:
+            self.cache.close()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        # Cache lookup is synchronous (SQLite-backed).
+        cached_response = _check_cache(request, self.cache, self.controller)
+        if cached_response is not None:
+            return cached_response
+
+        # Call original async transport
+        if __debug__:
+            log_request(request)
+            collect_request(request)
+        response = await self.transport.handle_async_request(request)
+
+        # Cache update is also synchronous.
+        revalidated = _update_cache(
+            response, cached_response, request, self.cache, self.controller
+        )
+        if revalidated is not None:
+            return revalidated
+        if __debug__:
+            collect_response(response)
+        return response

--- a/tiled/iterviews.py
+++ b/tiled/iterviews.py
@@ -88,6 +88,45 @@ class KeysView(IterViewBase):
         yield from self._keys_slice(0, None, 1, self._page_size)
 
 
+class AsyncKeysView(KeysView):
+    """
+    An async, sliceable, iterable view of keys.
+    """
+
+    async def __getitem__(self, index_or_slice):
+        if isinstance(index_or_slice, int):
+            if index_or_slice < 0:
+                index_or_slice = -1 - index_or_slice
+                direction = -1
+            else:
+                direction = 1
+            keys = list(
+                await self._keys_slice(index_or_slice, 1 + index_or_slice, direction, 1)
+            )
+            try:
+                (key,) = keys
+            except ValueError:
+                raise IndexError("Index out of range")
+            return key
+        elif isinstance(index_or_slice, slice):
+            start, stop, direction = slice_to_interval(index_or_slice)
+            if stop is not None:
+                page_size = abs(start - stop)
+                if self._page_size is not None:
+                    page_size = min(page_size, self._page_size)
+            else:
+                page_size = None
+            return list(await self._keys_slice(start, stop, direction, page_size))
+        else:
+            raise TypeError(
+                f"{index_or_slice} must be an int or slice, not {type(index_or_slice)}"
+            )
+
+    async def __aiter__(self):
+        async for key in self._keys_slice(0, None, 1, self._page_size):
+            yield key
+
+
 class ItemsView(IterViewBase):
     """
     A sliceable, iterable view of (key, value) pairs.
@@ -138,6 +177,47 @@ class ItemsView(IterViewBase):
 
     def __iter__(self):
         yield from self._items_slice(0, None, 1, self._page_size)
+
+
+class AsyncItemsView(ItemsView):
+    """
+    An async, sliceable, iterable view of (key, value) pairs.
+    """
+
+    async def __getitem__(self, index_or_slice):
+        if isinstance(index_or_slice, int):
+            if index_or_slice < 0:
+                index_or_slice = -1 - index_or_slice
+                direction = -1
+            else:
+                direction = 1
+            items = list(
+                await self._items_slice(
+                    index_or_slice, 1 + index_or_slice, direction, 1
+                )
+            )
+            try:
+                (item,) = items
+            except ValueError:
+                raise IndexError("Index out of range")
+            return item
+        elif isinstance(index_or_slice, slice):
+            start, stop, direction = slice_to_interval(index_or_slice)
+            if stop is not None:
+                page_size = abs(start - stop)
+                if self._page_size is not None:
+                    page_size = min(page_size, self._page_size)
+            else:
+                page_size = None
+            return list(await self._items_slice(start, stop, direction, page_size))
+        else:
+            raise TypeError(
+                f"{index_or_slice} must be an int or slice, not {type(index_or_slice)}"
+            )
+
+    async def __aiter__(self):
+        async for item in self._items_slice(0, None, 1, self._page_size):
+            yield item
 
 
 class ValuesView(IterViewBase):
@@ -194,6 +274,53 @@ class ValuesView(IterViewBase):
 
     def __iter__(self):
         for key, value in self._items_slice(0, None, 1, self._page_size):
+            yield value
+
+
+class AsyncValuesView(ValuesView):
+    """
+    An async, sliceable, iterable view of values.
+    """
+
+    async def __getitem__(self, index_or_slice):
+        if isinstance(index_or_slice, int):
+            if index_or_slice < 0:
+                index_or_slice = -1 - index_or_slice
+                direction = -1
+            else:
+                direction = 1
+            items = list(
+                await self._items_slice(
+                    index_or_slice, 1 + index_or_slice, direction, 1
+                )
+            )
+            try:
+                (item,) = items
+            except ValueError:
+                raise IndexError("Index out of range")
+            _key, value = item
+            return value
+        elif isinstance(index_or_slice, slice):
+            start, stop, direction = slice_to_interval(index_or_slice)
+            if stop is not None:
+                page_size = abs(start - stop)
+                if self._page_size is not None:
+                    page_size = min(page_size, self._page_size)
+            else:
+                page_size = None
+            return [
+                value
+                async for _key, value in self._items_slice(
+                    start, stop, direction, page_size
+                )
+            ]
+        else:
+            raise TypeError(
+                f"{index_or_slice} must be an int or slice, not {type(index_or_slice)}"
+            )
+
+    async def __aiter__(self):
+        async for key, value in self._items_slice(0, None, 1, self._page_size):
             yield value
 
 


### PR DESCRIPTION
Lay the groundwork for an async client by adding foundational async-compatible infrastructure:

- Refactor Transport to extract _check_cache() and _update_cache() helpers shared between sync and async transports
- Add AsyncTransport (httpx.AsyncBaseTransport) mirroring Transport for use with httpx.AsyncClient
- Add AsyncKeysView, AsyncItemsView, AsyncValuesView to iterviews.py for async container iteration
- Fix ByteStreamWrapper.__aiter__ to not await the synchronous cache callback (cache.set is backed by synchronous SQLite)
- Remove the commented-out AsyncCacheControlTransport placeholder, replaced by the real AsyncTransport implementation

### Checklist
- [ ] Add a Changelog entry
- [ ] Add the ticket number which this PR closes to the comment section
